### PR TITLE
fix(rime-install): sudo pacapt command not found

### DIFF
--- a/public/rime-install
+++ b/public/rime-install
@@ -23,11 +23,15 @@ pacapt() {
     "$PACAPT" "$@"
 }
 
+sudo_pacapt() {
+    sudo "$PACAPT" "$@"
+}
+
 echo "Updating package list..."
-sudo pacapt -Sy
+sudo_pacapt -Sy
 
 if ! command -v git &> /dev/null; then
-    sudo pacapt -S git --noconfirm
+    sudo_pacapt -S git --noconfirm
 fi
 
 FRONTEND="${1:-ibus}"
@@ -43,7 +47,7 @@ fi
 
 install_ibus() {
     echo "Installing ibus/ibus-rime..."
-    if sudo pacapt -S ibus ibus-rime --noconfirm; then
+    if sudo_pacapt -S ibus ibus-rime --noconfirm; then
         echo ""
         echo "Successfully installed ibus/ibus-rime"
         export rime_frontend="ibus-rime"
@@ -55,7 +59,7 @@ install_ibus() {
 
 install_fcitx5() {
     echo "Installing fcitx5/fcitx5-rime..."
-    if sudo pacapt -S fcitx5 fcitx5-qt fcitx5-gtk fcitx5-configtool fcitx5-rime --noconfirm; then
+    if sudo_pacapt -S fcitx5 fcitx5-qt fcitx5-gtk fcitx5-configtool fcitx5-rime --noconfirm; then
         echo ""
         echo "Successfully installed fcitx5/fcitx5-rime"
         export rime_frontend="fcitx5-rime"


### PR DESCRIPTION
Fix #8 

The issue is that `sudo` does not sees the `pacapt` shell function.

Proposed solution: introduce a `sudo_pacapt` function and change `sudo pacapt` commands to `sudo_pacapt`

