### PR TITLE
fix(rime-install): remove --noconfirm option that is not understood by some package managers

### DIFF
--- a/public/rime-install
+++ b/public/rime-install
@@ -27,7 +27,7 @@ echo "Updating package list..."
 sudo pacapt -Sy
 
 if ! command -v git &> /dev/null; then
-    sudo pacapt -S git --noconfirm
+    sudo pacapt -S git
 fi
 
 FRONTEND="${1:-ibus}"
@@ -43,7 +43,7 @@ fi
 
 install_ibus() {
     echo "Installing ibus/ibus-rime..."
-    if sudo pacapt -S ibus ibus-rime --noconfirm; then
+    if sudo pacapt -S ibus ibus-rime; then
         echo ""
         echo "Successfully installed ibus/ibus-rime"
         export rime_frontend="ibus-rime"
@@ -55,7 +55,7 @@ install_ibus() {
 
 install_fcitx5() {
     echo "Installing fcitx5/fcitx5-rime..."
-    if sudo pacapt -S fcitx5 fcitx5-qt fcitx5-gtk fcitx5-configtool fcitx5-rime --noconfirm; then
+    if sudo pacapt -S fcitx5 fcitx5-qt fcitx5-gtk fcitx5-configtool fcitx5-rime; then
         echo ""
         echo "Successfully installed fcitx5/fcitx5-rime"
         export rime_frontend="fcitx5-rime"


### PR DESCRIPTION
Fix #9 

The issue is that there is a bug on `--noconfirm` option of `pacapt`, which makes the installation fails in some environments (e.g. using `apt-get` package manager).

Proposed solution: remove usage of that option and let the user confirm interactively.